### PR TITLE
fix (vector): Fixes the error in the rotated_radians method in the Vector class

### DIFF
--- a/geom2d/tests/vector_test.py
+++ b/geom2d/tests/vector_test.py
@@ -93,6 +93,16 @@ class TestVector(unittest.TestCase):
         expected = Vector(1 / sqrt2, 1 / sqrt2)
         self.assertEqual(expected, actual)
 
+    def test_rotate_right_angle(self):
+        actual = self.east.rotated_radians(math.pi / 2)
+        expected = Vector(0, 1)
+        self.assertEqual(expected, actual)
+
+    def test_rotate_straight_angle(self):
+        actual = self.north_east.rotated_radians(math.pi)
+        expected = Vector(-1, -1)
+        self.assertEqual(expected, actual)
+
     def test_rotate_negative_angle(self):
         sqrt2 = math.sqrt(2)
         actual = self.east.rotated_radians(-math.pi / 4)

--- a/geom2d/vector.py
+++ b/geom2d/vector.py
@@ -177,7 +177,7 @@ class Vector:
         sin = math.sin(radians)
         return Vector(
             self.u * cos - self.v * sin,
-            self.u * sin - self.v * cos
+            self.u * sin + self.v * cos
         )
 
     def perpendicular(self):


### PR DESCRIPTION
Closes #1

# Context

The formula to rotate a vector is defined in Chapter 4 as follows:

<img width="1091" alt="Screenshot 2021-04-24 at 11 23 28" src="https://user-images.githubusercontent.com/7513343/115954134-a0645100-a4ef-11eb-93ad-c62ea1d5bd93.png">

but the code mistakenly did:

```python
 def rotated_radians(self, radians):
        cos = math.cos(radians)
        sin = math.sin(radians)
        return Vector(
            self.u * cos - self.v * sin,
            self.u * sin - self.v * cos
        )
```

This PR adds a test that surfaces the error and fixes it.

# Postmortem

None of the test caught this error earlier because the vector used in all of the rotation cases had a vertical projection equal to zero. Thus, the zero multiplied by the cosine was always zero, and therefore the sign was lost.
Using the vector `{ 1, 1 }` in the `test_rotate_straight_angle` test, this error is surfaced.